### PR TITLE
design : 메인페이지 카드형 리스트 컴포넌트 작업중

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "blog-app": "file:",
     "next": "15.1.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
@@ -19,6 +20,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "autoprefixer": "^10.4.20",
+    "daisyui": "^4.12.23",
     "eslint": "^9",
     "eslint-config-next": "15.1.3",
     "postcss": "^8.4.49",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,8 @@
-import React from "react";
-
+import PostItem from "@/components/posts/postItem";
 export default function Page() {
-  return <div className="h-full text-white"></div>;
+  return (
+    <div className="h-full text-white">
+      <PostItem />
+    </div>
+  );
 }

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -12,7 +12,7 @@ export default function Header() {
           로그인
         </button>
       </div>
-      <Modal title="로그인" contents="로그인창입니다" />
+      <Modal title="로그인" contents="이메일로 로그인" />
     </div>
   );
 }

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -1,10 +1,18 @@
+import Modal from "./modal";
+
 export default function Header() {
   return (
-    <div className="h-16 bg-black border-b-[1.5px] border-b-slate-300 sticky top-0 z-10 text-slate-200 flex items-center place-content-between px-6 text-sm">
-      <div className="w-12">LOGO</div>
-      <button className="w-20 h-10 border-[1.5px] rounded-3xl border-slate-200">
-        로그인
-      </button>
+    <div>
+      <div className="h-16 bg-black border-b-[1.5px] border-b-slate-300 sticky top-0 z-10 text-slate-200 flex items-center place-content-between px-6 text-sm">
+        <div className="w-12">LOGO</div>
+        <button
+          className="w-20 h-10 border-[1.5px] rounded-3xl border-slate-200"
+          onClick={() => document.getElementById("my_modal").showModal()}
+        >
+          로그인
+        </button>
+      </div>
+      <Modal title="로그인" contents="로그인창입니다" />
     </div>
   );
 }

--- a/src/components/common/modal.tsx
+++ b/src/components/common/modal.tsx
@@ -16,8 +16,21 @@ export default function Modal({
               ✕
             </button>
           </form>
-          <h3 className="font-bold text-lg text-center">{title}</h3>
-          <p className="py-4 text-center">{contents}</p>
+          <div className="flex flex-col items-center p-4">
+            <h3 className="font-bold text-2xl text-center">{title}</h3>
+            <p className="py-4 text-center">{contents}</p>
+            <input
+              type="text"
+              placeholder="이메일을 입력해주세요."
+              className="input input-bordered w-full max-w-xs"
+            />
+            <button className="w-20 h-10 border-[1.5px] rounded-3xl border-slate-200 mt-6">
+              로그인
+            </button>
+            <p className="py-4 text-center">
+              아직 회원이 아니신가요? 회원가입 하러가기
+            </p>
+          </div>
         </div>
       </dialog>
     </div>

--- a/src/components/common/modal.tsx
+++ b/src/components/common/modal.tsx
@@ -1,0 +1,25 @@
+interface ModalProps {
+  title: string;
+  contents: string;
+}
+
+export default function Modal({
+  title,
+  contents,
+}: ModalProps): React.ReactElement {
+  return (
+    <div>
+      <dialog id="my_modal" className="modal">
+        <div className="modal-box">
+          <form method="dialog">
+            <button className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+              ✕
+            </button>
+          </form>
+          <h3 className="font-bold text-lg text-center">{title}</h3>
+          <p className="py-4 text-center">{contents}</p>
+        </div>
+      </dialog>
+    </div>
+  );
+}

--- a/src/components/common/radioLabel.tsx
+++ b/src/components/common/radioLabel.tsx
@@ -20,7 +20,7 @@ function RadioLabel({
         defaultChecked={defaultChecked}
         onClick={onClick}
       />
-      <span className="label-text">{label}</span>
+      <span className="label-text ml-2">{label}</span>
     </label>
   );
 }

--- a/src/components/common/radioLabel.tsx
+++ b/src/components/common/radioLabel.tsx
@@ -1,0 +1,28 @@
+interface RadioLabelProps {
+  label: string;
+  name: string;
+  defaultChecked?: boolean;
+  onClick?: () => void;
+}
+
+function RadioLabel({
+  label,
+  name,
+  defaultChecked,
+  onClick,
+}: RadioLabelProps): React.ReactElement {
+  return (
+    <label className={"label cursor-pointer"}>
+      <input
+        type="radio"
+        name={name}
+        className="radio radio-primary"
+        defaultChecked={defaultChecked}
+        onClick={onClick}
+      />
+      <span className="label-text">{label}</span>
+    </label>
+  );
+}
+
+export default RadioLabel;

--- a/src/components/posts/cardTypeItem.tsx
+++ b/src/components/posts/cardTypeItem.tsx
@@ -1,0 +1,30 @@
+interface CardTypeItemProps {
+  title: string;
+  contents: string;
+  writer: string;
+  imgUrl?: string;
+}
+
+function CardTypeItem({
+  title,
+  contents,
+  writer,
+  imgUrl,
+}: CardTypeItemProps): React.ReactElement {
+  return (
+    <div className="w-[calc(25%-1rem)] card bg-base-100 shadow-xl">
+      <figure>
+        <img src={imgUrl} alt="게시글" />
+      </figure>
+      <div className="card-body">
+        <h2 className="card-title">{title.slice(0, 30)}</h2>
+        <p>{contents.slice(0, 60)}</p>
+        <div className="card-actions justify-end">
+          <button className="btn btn-primary">{writer}</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CardTypeItem;

--- a/src/components/posts/cardTypeItem.tsx
+++ b/src/components/posts/cardTypeItem.tsx
@@ -19,8 +19,9 @@ function CardTypeItem({
       <div className="card-body">
         <h2 className="card-title">{title.slice(0, 30)}</h2>
         <p>{contents.slice(0, 60)}</p>
-        <div className="card-actions justify-end">
-          <button className="btn btn-primary">{writer}</button>
+
+        <div className="card-actions justify-end mt-3">
+          <p>{writer}</p>
         </div>
       </div>
     </div>

--- a/src/components/posts/listTypeItem.tsx
+++ b/src/components/posts/listTypeItem.tsx
@@ -1,0 +1,30 @@
+interface ListTypeItemProps {
+  title: string;
+  contents: string;
+  writer: string;
+  imgUrl?: string;
+}
+
+function ListTypeItem({
+  title,
+  contents,
+  writer,
+  imgUrl,
+}: ListTypeItemProps): React.ReactElement {
+  return (
+    <div className="card bg-base-100 w-full shadow-xl mb-5">
+      <div className="card-body flex flex-row">
+        <img className="w-40 mr-5 rounded-sm" src={imgUrl} alt="게시글" />
+        <div>
+          <h2 className="card-title">{title}</h2>
+          <p>{contents}</p>
+          <div className="card-actions justify-end">
+            <p>{writer}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ListTypeItem;

--- a/src/components/posts/postItem.tsx
+++ b/src/components/posts/postItem.tsx
@@ -1,20 +1,41 @@
-// import React, { useState } from "react";
+"use client";
+import React, { useState } from "react";
+import RadioLabel from "../common/radioLabel";
 
 export default function PostItem() {
-  //const [itemType, setItemType] = useState("card");
+  const [itemType, setItemType] = useState("card");
 
   return (
-    <div className="w-10/12 h-full m-auto mt-32 flex flex-wrap">
-      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+    <div className="w-10/12 m-auto">
+      <div className="m-auto mt-32 mb-6 flex justify-center">
+        <RadioLabel
+          label="카드형"
+          name="radio-1"
+          defaultChecked={true}
+          onClick={() => setItemType("card")}
+        />
+        <RadioLabel
+          label="리스트형"
+          name="radio-1"
+          onClick={() => setItemType("list")}
+        />
+      </div>
+      {itemType === "card" ? (
+        <div className="h-full flex flex-wrap justify-center">
+          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+        </div>
+      ) : (
+        <h1>리스트형으로 들어와야함</h1>
+      )}
     </div>
   );
 }

--- a/src/components/posts/postItem.tsx
+++ b/src/components/posts/postItem.tsx
@@ -1,0 +1,20 @@
+// import React, { useState } from "react";
+
+export default function PostItem() {
+  //const [itemType, setItemType] = useState("card");
+
+  return (
+    <div className="w-10/12 h-full m-auto mt-32 flex flex-wrap">
+      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+      <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+    </div>
+  );
+}

--- a/src/components/posts/postItem.tsx
+++ b/src/components/posts/postItem.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import RadioLabel from "../common/radioLabel";
 import CardTypeItem from "./cardTypeItem";
+import ListTypeItem from "./listTypeItem";
 
 interface PostData {
   userId: string;
@@ -48,7 +49,17 @@ export default function PostItem() {
           ))}
         </div>
       ) : (
-        <h1>리스트형으로 들어와야함</h1>
+        <div>
+          {postData.map((item) => (
+            <ListTypeItem
+              key={item.id}
+              title={item.title}
+              contents={item.body}
+              writer={item.userId}
+              imgUrl="https://img.daisyui.com/images/stock/photo-1606107557195-0e29a4b5b4aa.webp"
+            />
+          ))}
+        </div>
       )}
     </div>
   );

--- a/src/components/posts/postItem.tsx
+++ b/src/components/posts/postItem.tsx
@@ -1,13 +1,28 @@
 "use client";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import RadioLabel from "../common/radioLabel";
+import CardTypeItem from "./cardTypeItem";
+
+interface PostData {
+  userId: string;
+  id: number;
+  title: string;
+  body: string;
+}
 
 export default function PostItem() {
   const [itemType, setItemType] = useState("card");
+  const [postData, setPostData] = useState<PostData[]>([]);
+
+  useEffect(() => {
+    fetch("https://jsonplaceholder.typicode.com/posts")
+      .then((response) => response.json())
+      .then((json) => setPostData(json.slice(0, 10)));
+  }, []);
 
   return (
     <div className="w-10/12 m-auto">
-      <div className="m-auto mt-32 mb-6 flex justify-center">
+      <div className="m-auto mt-28 mb-6 flex justify-end">
         <RadioLabel
           label="카드형"
           name="radio-1"
@@ -21,17 +36,16 @@ export default function PostItem() {
         />
       </div>
       {itemType === "card" ? (
-        <div className="h-full flex flex-wrap justify-center">
-          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
-          <div className="w-1/6 h-80 bg-slate-50 rounded-xl mx-3.5"></div>
+        <div className="h-full flex flex-wrap gap-5">
+          {postData.map((item) => (
+            <CardTypeItem
+              key={item.id}
+              title={item.title}
+              contents={item.body}
+              writer={item.userId}
+              imgUrl="https://img.daisyui.com/images/stock/photo-1606107557195-0e29a4b5b4aa.webp"
+            />
+          ))}
         </div>
       ) : (
         <h1>리스트형으로 들어와야함</h1>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import daisyui from "daisyui";
+
 module.exports = {
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
@@ -47,5 +49,5 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [daisyui],
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 페이지에 새로운 `PostItem` 컴포넌트 추가
  - 게시물 레이아웃에 10개의 개별 항목 렌더링
  - 사용자가 "카드"와 "리스트" 레이아웃을 선택할 수 있는 라디오 버튼 추가
  - 모달 컴포넌트 추가로 로그인 기능 구현

- **스타일**
  - Tailwind CSS를 사용한 레이아웃 및 컴포넌트 스타일링
  - `daisyui` 플러그인 추가로 UI 구성 요소 및 유틸리티 클래스 향상

- **문서화**
  - 새로운 `RadioLabel`, `CardTypeItem`, `ListTypeItem`, `Modal` 컴포넌트에 대한 인터페이스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->